### PR TITLE
fix: Chage Delegation package name

### DIFF
--- a/tokendelegate/README.md
+++ b/tokendelegate/README.md
@@ -1,4 +1,4 @@
-# Delegation Token
+# Delegated Token
 
 ## Overview
 
@@ -6,7 +6,7 @@ The `delegation` package provides a mechanism for token holders to delegate thei
 
 This is useful in governance systems where token holders may want to participate in decision-making processes but delegate the actual voting to more active or reliable participants.
 
-## Flow of Delegation
+## Flow of Token Delegation
 
 The following diagram illustrates the flow of delegation in the `delegation` package:
 

--- a/tokendelegate/delegated.gno
+++ b/tokendelegate/delegated.gno
@@ -1,4 +1,4 @@
-package delegation
+package tokendelegate
 
 import (
 	"std"

--- a/tokendelegate/delegated_test.gno
+++ b/tokendelegate/delegated_test.gno
@@ -1,4 +1,4 @@
-package delegation
+package tokendelegate
 
 import (
 	"errors"

--- a/tokendelegate/getter.gno
+++ b/tokendelegate/getter.gno
@@ -1,4 +1,4 @@
-package delegation
+package tokendelegate
 
 import (
 	"std"

--- a/tokendelegate/gno.mod
+++ b/tokendelegate/gno.mod
@@ -1,4 +1,4 @@
-module gno.land/r/governance/delegation
+module gno.land/r/governance/tokendelegate
 
 require (
 	gno.land/p/demo/grc/grc20 v0.0.0-latest


### PR DESCRIPTION
# Description

Closes #21

change package name `delegation` to `tokendelegate`.
