### PR TITLE
feat(tokendelegate): use `avl` to store allowance data

### DIFF
--- a/tokendelegate/delegated.gno
+++ b/tokendelegate/delegated.gno
@@ -3,6 +3,7 @@ package tokendelegate
 import (
 	"std"
 
+	"gno.land/p/demo/avl"
 	"gno.land/p/demo/grc/grc20"
 	u256 "gno.land/p/demo/uint256"
 )
@@ -32,7 +33,8 @@ type DelegatedToken struct {
 	balances    map[std.Address]*u256.Uint
 
 	// allowances tracks the spending allowances for delegated tokens.
-	allowances  map[std.Address]map[std.Address]*u256.Uint
+	allowances  *avl.Tree
+	// allowances  map[std.Address]map[std.Address]*u256.Uint
 
 	// totoalSupply represents the total amount of delegated tokens in circulation.
 	totalSupply *u256.Uint
@@ -60,35 +62,12 @@ func New(staker std.Address, token grc20.Token, name string, symbol string, cont
 		token:       token,
 		delegatedTo: make(map[std.Address]std.Address),
 		balances:    make(map[std.Address]*u256.Uint),
+		allowances:  avl.NewTree(),
 		totalSupply: u256.Zero(),
 		name:        name,
 		symbol:      symbol,
 		contractAddr: contractAddr,
 	}
-}
-
-// GetStaker returns the addrress of the staker that this delegated token wrapper uses.
-func GetStaker() std.Address {
-	if gDelegatedToken == nil {
-		panic("DelegatedToken not initialized")
-	}
-	return gDelegatedToken.staker
-}
-
-// GetDelegatedTo returns the address to whom the owner is delegated.
-func GetDelegatedTo(owner string) std.Address {
-	if gDelegatedToken == nil {
-		panic("DelegatedToken not initialized")
-	}
-
-	ownerAddr := std.Address(owner)
-	delegatee, exists := gDelegatedToken.delegatedTo[ownerAddr]
-	if !exists {
-		// if not explicitly delegated, return owner
-		return ownerAddr
-	}
-
-	return delegatee
 }
 
 func Delegate(owner, to string) {
@@ -100,9 +79,10 @@ func Delegate(owner, to string) {
 	toAddr := std.Address(to)
 
 	currDelegatee := GetDelegatedTo(owner)
+	delegateeAddr := std.Address(currDelegatee)
 
 	// if the new delegation is different from the current one
-	if currDelegatee != toAddr {
+	if delegateeAddr != toAddr {
 		gDelegatedToken.delegatedTo[ownerAddr] = toAddr
 
 		std.Emit(
@@ -226,4 +206,14 @@ func BalanceOf(account string) *u256.Uint {
 	}
 
 	return balance
+}
+
+// SetAllowance sets the spending allowance for a spender.
+func SetAllowance(owner, spender std.Address, amount *u256.Uint) {
+	if gDelegatedToken == nil {
+		panic("DelegatedToken not initialized")
+	}
+
+	key := owner.String() + ":" + spender.String()
+	gDelegatedToken.allowances.Set(key, amount)
 }

--- a/tokendelegate/delegated_test.gno
+++ b/tokendelegate/delegated_test.gno
@@ -13,7 +13,7 @@ import (
 // mockGRC20 is a mock implementation of the IGRC20 interface for testing
 type mockGRC20 struct {
 	balances    map[std.Address]uint64
-	allowances  map[std.Address]map[std.Address]uint64
+	allowances  *avl.Tree
 	totalSupply uint64
 	name        string
 	symbol      string
@@ -27,7 +27,7 @@ type mockGRC20 struct {
 func newMockGRC20(name, symbol string, decimals uint8) *mockGRC20 {
 	return &mockGRC20{
 		balances:   make(map[std.Address]uint64),
-		allowances: make(map[std.Address]map[std.Address]uint64),
+		allowances: avl.NewTree(),
 		name:       name,
 		symbol:     symbol,
 		decimals:   decimals,
@@ -65,15 +65,18 @@ func (m *mockGRC20) Transfer(to std.Address, amount uint64) error {
 }
 
 func (m *mockGRC20) Allowance(owner, spender std.Address) uint64 {
-	return m.allowances[owner][spender]
+	key := owner.String() + ":" + spender.String()
+	value, exists := m.allowances.Get(key)
+	if !exists {
+		return 0
+	}
+	return value.(uint64)
 }
 
 func (m *mockGRC20) Approve(spender std.Address, amount uint64) error {
 	owner := std.GetOrigCaller()
-	if m.allowances[owner] == nil {
-		m.allowances[owner] = make(map[std.Address]uint64)
-	}
-	m.allowances[owner][spender] = amount
+	key := owner.String() + ":" + spender.String()
+	m.allowances.Set(key, amount)
 	return nil
 }
 

--- a/tokendelegate/delegated_test.gno
+++ b/tokendelegate/delegated_test.gno
@@ -5,6 +5,7 @@ import (
 	"std"
 	"testing"
 
+	"gno.land/p/demo/avl"
 	"gno.land/p/demo/testutils"
 	u256 "gno.land/p/demo/uint256"
 )
@@ -98,7 +99,7 @@ func TestGetStaker(t *testing.T) {
 	New(testAddr, nil, "test token", "TST", "")
 
 	result := GetStaker()
-	if result != testAddr {
+	if result != testAddr.String() {
 		t.Errorf("GetStaer() = %v, want %v", result, testAddr)
 	}
 }
@@ -121,41 +122,41 @@ func TestDelegatedTo(t *testing.T) {
 
 	// Test 1: Initial state - should be delegated to self
 	result := GetDelegatedTo(owner1)
-	if result != owner1Addr {
+	if result != owner1Addr.String() {
 		t.Errorf("Initial GetDelegatedTo(owner1) = %v, want %v", result, owner1)
 	}
 
 	// Test 2: Delegate owner1 to delegate1
 	Delegate(owner1, delegate1)
 	result = GetDelegatedTo(owner1)
-	if result != delegate1Addr {
+	if result != delegate1Addr.String() {
 		t.Errorf("After delegation, GetDelegatedTo(owner1) = %v, want %v", result, delegate1)
 	}
 
 	// Test 3: Delegate owner2 to delegate2
 	Delegate(owner2, delegate2)
 	result = GetDelegatedTo(owner2)
-	if result != delegate2Addr {
+	if result != delegate2Addr.String() {
 		t.Errorf("After delegation, GetDelegatedTo(owner2) = %v, want %v", result, delegate2)
 	}
 
 	// Test 4: Check owner1's delegation hasn't changed
 	result = GetDelegatedTo(owner1)
-	if result != delegate1Addr {
+	if result != delegate1Addr.String() {
 		t.Errorf("After owner2 delegation, GetDelegatedTo(owner1) = %v, want %v", result, delegate1)
 	}
 
 	// Test 5: Change owner1's delegation
 	Delegate(owner1, delegate2)
 	result = GetDelegatedTo(owner1)
-	if result != delegate2Addr {
+	if result != delegate2Addr.String() {
 		t.Errorf("After changing delegation, GetDelegatedTo(owner1) = %v, want %v", result, delegate2)
 	}
 
 	// Test 6: Delegate back to self
 	Delegate(owner1, owner1)
 	result = GetDelegatedTo(owner1)
-	if result != owner1Addr {
+	if result != owner1Addr.String() {
 		t.Errorf("After delegating to self, GetDelegatedTo(owner1) = %v, want %v", result, owner1)
 	}
 
@@ -164,7 +165,7 @@ func TestDelegatedTo(t *testing.T) {
 	nonExistentOwner := nonExistentOwnerAddr.String()
 
 	result = GetDelegatedTo(nonExistentOwner)
-	if result != nonExistentOwnerAddr {
+	if result != nonExistentOwnerAddr.String() {
 		t.Errorf("GetDelegatedTo(nonExistentOwner) = %v, want %v", result, nonExistentOwner)
 	}
 }

--- a/tokendelegate/getter.gno
+++ b/tokendelegate/getter.gno
@@ -5,52 +5,103 @@ import (
 
 	"gno.land/p/demo/grc/grc20"
 	u256 "gno.land/p/demo/uint256"
+    "gno.land/p/demo/ufmt"
 )
 
-// GetStaker returns the address of the entity staking the tokens.
-func (dt *DelegatedToken) GetStaker() std.Address {
-    return dt.staker
+// GetStaker returns the addrress of the staker that this delegated token wrapper uses.
+func GetStaker() string {
+	if gDelegatedToken == nil {
+		panic("DelegatedToken not initialized")
+	}
+	return gDelegatedToken.staker.String()
+}
+
+// GetDelegatedTo returns the address to whom the owner is delegated.
+func GetDelegatedTo(owner string) string {
+	if gDelegatedToken == nil {
+		panic("DelegatedToken not initialized")
+	}
+
+	ownerAddr := std.Address(owner)
+	delegatee, exists := gDelegatedToken.delegatedTo[ownerAddr]
+	if !exists {
+		// if not explicitly delegated, return owner
+		return ownerAddr.String()
+	}
+
+	return delegatee.String()
 }
 
 // GetToken returns the underlying GRC20 token being staked.
-func (dt *DelegatedToken) GetToken() grc20.Token {
-    return dt.token
-}
-
-// GetDelegatedTo returns the delegate address for the given owner address.
-func (dt *DelegatedToken) GetDelegatedTo(owner std.Address) std.Address {
-    return dt.delegatedTo[owner]
+func GetToken() grc20.Token {
+    if gDelegatedToken == nil {
+        panic("DelegatedToken not initialized")
+    }
+    return gDelegatedToken.token
 }
 
 // GetBalance returns the delegated token balance for the given account.
-func (dt *DelegatedToken) GetBalance(account std.Address) *u256.Uint {
-    return dt.balances[account]
+func GetBalance(account string) string {
+    if gDelegatedToken == nil {
+        panic("DelegatedToken not initialized")
+    }
+
+    accountAddr := std.Address(account)
+    if !accountAddr.IsValid() {
+        panic(ufmt.Sprintf("invalid account address: %s", account))
+    }
+    balance, exists := gDelegatedToken.balances[accountAddr]
+    if !exists {
+        return "0"
+    }
+
+    return balance.ToString()
 }
 
 // GetAllowance returns the spending allowance for the given owner and spender.
-func (dt *DelegatedToken) GetAllowance(owner, spender std.Address) *u256.Uint {
-    if dt.allowances[owner] == nil {
-        return u256.Zero()
-    }
-    return dt.allowances[owner][spender]
+func GetAllowance(owner, spender string) string {
+	if gDelegatedToken == nil {
+		panic("DelegatedToken not initialized")
+	}
+
+	key := owner + ":" + spender
+	allowance, exists := gDelegatedToken.allowances.Get(key)
+	if !exists {
+		return "0"
+	}
+
+	res := allowance.(*u256.Uint)
+    return res.ToString()
 }
 
 // GetTotalSupply returns the total amount of delegated tokens in circulation.
-func (dt *DelegatedToken) GetTotalSupply() *u256.Uint {
-    return dt.totalSupply
+func GetTotalSupply() string {
+    if gDelegatedToken == nil {
+        panic("DelegatedToken not initialized")
+    }
+    return gDelegatedToken.totalSupply.ToString()
 }
 
 // GetName returns the name of the delegated token.
-func (dt *DelegatedToken) GetName() string {
-    return dt.name
+func GetName() string {
+    if gDelegatedToken == nil {
+        panic("DelegatedToken not initialized")
+    }
+    return gDelegatedToken.name
 }
 
 // GetSymbol returns the symbol of the delegated token.
-func (dt *DelegatedToken) GetSymbol() string {
-    return dt.symbol
+func GetSymbol() string {
+    if gDelegatedToken == nil {
+        panic("DelegatedToken not initialized")
+    }
+    return gDelegatedToken.symbol
 }
 
 // GetDecimals returns the number of decimal places for the delegated token.
-func (dt *DelegatedToken) GetDecimals() uint8 {
-    return dt.decimals
+func GetDecimals() uint8 {
+    if gDelegatedToken == nil {
+        panic("DelegatedToken not initialized")
+    }
+    return gDelegatedToken.decimals
 }

--- a/tokendelegate/gno.mod
+++ b/tokendelegate/gno.mod
@@ -1,6 +1,7 @@
 module gno.land/r/governance/tokendelegate
 
 require (
+	gno.land/p/demo/avl v0.0.0-latest
 	gno.land/p/demo/grc/grc20 v0.0.0-latest
 	gno.land/p/demo/testutils v0.0.0-latest
 	gno.land/p/demo/uint256 v0.0.0-latest


### PR DESCRIPTION
# Description

- change allowances type (double map -> avl)
- update tests
- pure getter (execpt GetToken)