### PR TITLE
fix(staker): Fix GetDelegatedCumulative Function

### DIFF
--- a/staker/staker.gno
+++ b/staker/staker.gno
@@ -11,6 +11,10 @@ import (
 	"gno.land/p/demo/ufmt"
 )
 
+var getCurrentTime = func() uint64 {
+	return uint64(time.Now().Unix())
+}
+
 var (
 	ErrInsufficientBalance = errors.New("insufficient balance")
 	ErrUnauthorized        = errors.New("unauthorized")
@@ -82,7 +86,7 @@ func StakeAmount(delegate, amount string) {
 	// Update delegation history
 	gStaker.delegationHistory[delegateAddr] = append(gStaker.delegationHistory[delegateAddr], DelegationHistory{
 		amount:    gStaker.delegations[delegateAddr].Clone(),
-		timestamp: uint64(time.Now().Unix()),
+		timestamp: getCurrentTime(),
 	})
 }
 
@@ -141,41 +145,37 @@ func WithdrawAmount(delegate, recipient, amount string) {
 }
 
 // GetDelegatedCumulative gets the cumulative delegated amount * seconds for an address at a certain timestamp.
-func GetDelegatedCumulative(delegate string, timestamp uint64) (string, error) {
-	delegateAddr := std.Address(delegate)
-	if !delegateAddr.IsValid() {
-		panic(ufmt.Sprintf("invalid address: %s", delegate))
+func GetDelegatedCumulative(delegate std.Address, timestamp uint64) string { // return u256.String(), error
+	if timestamp > getCurrentTime() {
+		panic(ufmt.Sprintf("error: timestamp %d is in the future", timestamp))
 	}
 
-	if timestamp > uint64(time.Now().Unix()) {
-		panic("FUTURE")
+	numSnapshots := uint64(len(gStaker.delegationHistory[delegate]))
+	if numSnapshots == 0 {
+		return "0"
 	}
 
-	history, exists := gStaker.delegationHistory[delegateAddr]
-	if !exists || len(history) == 0 {
-		return u256.Zero().ToString(), nil
-	}
+	return findDelegatedCumulative(delegate, 0, numSnapshots, timestamp)
+}
 
-	var lastSnapshot DelegationHistory
-	var cumulativeAmount u256.Uint
+func findDelegatedCumulative(delegate std.Address, minIndex, maxIndexExclusive, timestamp uint64) string {
+    if minIndex >= maxIndexExclusive {
+        return "0"
+    }
 
-	for _, snapshot := range history {
-		if snapshot.timestamp > timestamp {
-			break
-		}
-		if lastSnapshot.timestamp != 0 {
-			duration := snapshot.timestamp - lastSnapshot.timestamp
-			cumulativeAmount.Add(&cumulativeAmount, u256.Zero().Mul(lastSnapshot.amount, u256.NewUint(duration)))
-		}
-		lastSnapshot = snapshot
-	}
+    snapshot := gStaker.delegationHistory[delegate][minIndex]
+    if snapshot.timestamp > timestamp {
+        return "0"
+    }
 
-	if lastSnapshot.timestamp < timestamp {
-		duration := timestamp - lastSnapshot.timestamp
-		cumulativeAmount.Add(&cumulativeAmount, u256.Zero().Mul(lastSnapshot.amount, u256.NewUint(duration)))
-	}
+    if minIndex == maxIndexExclusive-1 || timestamp < gStaker.delegationHistory[delegate][minIndex+1].timestamp {
+        diff := timestamp - snapshot.timestamp
+        delegatedAmount := gStaker.delegations[delegate]
+        cumulativeAmount := u256.NewUint(0).Mul(delegatedAmount, u256.NewUint(diff))
+        return cumulativeAmount.ToString()
+    }
 
-	return cumulativeAmount.ToString(), nil
+    return findDelegatedCumulative(delegate, minIndex+1, maxIndexExclusive, timestamp)
 }
 
 // GetAverageDelegated calculates the average delegated amount for a delegate over a given period

--- a/staker/staker_test.gno
+++ b/staker/staker_test.gno
@@ -234,6 +234,93 @@ func TestGetAverageDelegated(t *testing.T) {
 	}
 }
 
+func TestGetDelegatedCumulative(t *testing.T) {
+    baseTime := uint64(time.Now().Unix())
+
+    originalGetCurrentTime := getCurrentTime
+    defer func() { getCurrentTime = originalGetCurrentTime }()
+
+    var mockTime uint64
+    getCurrentTime = func() uint64 {
+        return mockTime
+    }
+
+    token := newMockGRC20("Test Token", "TST", 18)
+    Init(token)
+
+    delegatee := testutils.TestAddress("delegatee")
+
+    caller := std.GetOrigCaller()
+    token.balances[caller] = 12345
+
+    tests := []struct {
+        name        string
+        setupFunc   func()
+        timestamp   uint64
+        want        string
+        shouldPanic bool
+    }{
+        {
+            name:      "Initial state",
+            setupFunc: func() { mockTime = baseTime },
+            timestamp: baseTime,
+            want:      "0",
+        },
+        {
+            name: "Right after staking",
+            setupFunc: func() {
+                mockTime = baseTime + 1
+                StakeAmount(delegatee.String(), "12345")
+            },
+            timestamp: baseTime + 1,
+            want:      "0",
+        },
+        {
+            name:      "1 second after staking",
+            setupFunc: func() { mockTime = baseTime + 2 },
+            timestamp: baseTime + 2,
+            want:      "12345",
+        },
+        {
+            name:      "2 seconds after staking",
+            setupFunc: func() { mockTime = baseTime + 3 },
+            timestamp: baseTime + 3,
+            want:      "24690",
+        },
+        {
+            name:      "Past time",
+            setupFunc: func() {},
+            timestamp: baseTime,
+            want:      "0",
+        },
+        {
+            name:        "Future time",
+            setupFunc:   func() {},
+            timestamp:   baseTime + 1000,
+            shouldPanic: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            tt.setupFunc()
+
+            if tt.shouldPanic {
+                defer func() {
+                    if r := recover(); r == nil {
+                        t.Errorf("GetDelegatedCumulative() for future time should panic")
+                    }
+                }()
+            }
+
+            result := GetDelegatedCumulative(delegatee, tt.timestamp)
+            if result != tt.want {
+                t.Errorf("GetDelegatedCumulative() = %v, want %v", result, tt.want)
+            }
+        })
+    }
+}
+
 func TestGetAverageDelegatedOverLast(t *testing.T) {
 	token := newMockGRC20("Test Token", "TST", 42)
 	Init(token)


### PR DESCRIPTION
# Description

Improved the logic of the `GetDelegatedCumulative` function.


### 1. modify the `GetDelegatedCumulative` function
- Modify logic so that the cumulative amount is zero immediately after staking
- Reflect the correct delegation amount when calculating the cumulative amount

### 2. Modify StakeAmount function
- Use current time when updating delegation history